### PR TITLE
Pinning numpy version for torch vision reqs for backwards compatibility

### DIFF
--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -7,7 +7,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export BUILD_TYPE=wheel
 setup_env 0.11.0
 setup_wheel_python
-pip_install numpy pyyaml future ninja
+pip_install numpy==1.23.1 pyyaml future ninja
 pip_install --upgrade setuptools
 setup_pip_pytorch_version
 python setup.py clean

--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,13 @@ if os.getenv('PYTORCH_VERSION'):
     pytorch_dep += "==" + os.getenv('PYTORCH_VERSION')
 
 requirements = [
-    'numpy',
     pytorch_dep,
 ]
+
+# Pin numpy for backwards compatability
+numpy_ver = ' ==1.23.1'
+numpy_req = 'numpy'
+requirements.append(numpy_req + numpy_ver)
 
 # Excluding 8.3.0 because of https://github.com/pytorch/vision/issues/4146
 pillow_ver = ' >= 5.3.0, !=8.3.0'


### PR DESCRIPTION
Pinning numpy version used in torchvision release/0.11.2 branch due to issue encountered with numpy versions later than 1.24 on pytorch release/1.10.1 branch -(SWDEV-385058)

Local logs (wheel building)
```
pip install torch-1.10.1+rocm5.5-cp38-cp38-linux_x86_64.whl torchvision-0.11.2+rocm5.5-cp38-cp38-linux_x86_64.whl 
Processing ./torch-1.10.1+rocm5.5-cp38-cp38-linux_x86_64.whl
Processing ./torchvision-0.11.2+rocm5.5-cp38-cp38-linux_x86_64.whl
Collecting typing-extensions
  Downloading typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Collecting numpy==1.23.1
  Downloading numpy-1.23.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
     |████████████████████████████████| 17.1 MB 1.9 MB/s 
Collecting pillow!=8.3.0,>=5.3.0
  Downloading Pillow-9.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
     |████████████████████████████████| 3.3 MB 33.5 MB/s 
Installing collected packages: typing-extensions, torch, numpy, pillow, torchvision
Successfully installed numpy-1.23.1 pillow-9.4.0 torch-1.10.1+rocm5.5 torchvision-0.11.2+rocm5.5 typing-extensions-4.5.0

root@rocm-framework-8:~/pytorch# PYTORCH_TEST_WITH_ROCM=1 python3 test/test_torch.py -v TestTorch.test_parsing_intlist --verbose
Fail to import hypothesis in common_utils, tests are not derandomized
test_parsing_intlist (__main__.TestTorch) ... ok

PYTORCH_TEST_WITH_ROCM=1 python3 test/test_torch.py -v 
Ran 745 tests in 194.832s
OK (skipped=55)
```

Companion PR to update the numpy in requirements of torch release/1.10.1 here: (https://github.com/ROCmSoftwarePlatform/pytorch/pull/1203)