### PR TITLE
[release/0.16] limit numpy version less than 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if os.getenv("PYTORCH_VERSION"):
     pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
 requirements = [
-    "numpy",
+    "numpy<2",
     "requests",
     pytorch_dep,
 ]


### PR DESCRIPTION
This PR limits numpy version less then 2 in requirements because torchvision is built with numpy v1
pip installs numpy with highest available version 2.0.0 by default. And torchvision prints this message when imported
```
>>> import torchvision

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
``` 